### PR TITLE
Register listener for yell event

### DIFF
--- a/listener.lua
+++ b/listener.lua
@@ -4,6 +4,7 @@ frame:RegisterEvent("CHAT_MSG_PARTY_LEADER");
 frame:RegisterEvent("CHAT_MSG_RAID_LEADER");
 frame:RegisterEvent("CHAT_MSG_GUILD");
 frame:RegisterEvent("CHAT_MSG_SAY");
+frame:RegisterEvent("CHAT_MSG_YELL");
 frame:RegisterEvent("CHAT_MSG_WHISPER");
 frame:RegisterEvent("CHAT_MSG_BN_WHISPER");
 frame:RegisterEvent("CHAT_MSG_PARTY");-- Register our event

--- a/listener.lua
+++ b/listener.lua
@@ -49,6 +49,7 @@ end
 function isChatEvent(event)
     if (event=="CHAT_MSG_RAID" 
         or event=="CHAT_MSG_SAY" 
+        or event=="CHAT_MSG_YELL"
         or event=="CHAT_MSG_WHISPER" 
         or event=="CHAT_MSG_GUILD" 
         or event=="CHAT_MSG_PARTY" 


### PR DESCRIPTION
So it can also trigger off yells.
So demon hunters don't have to "say" scars. A yell is more on point lore wise? :)